### PR TITLE
Update iOS SDK to 1.6.1 and Android SDK to 1.5.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.oakam.survicate.survicate_flutter_sdk'
 version '2.1.1'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.32'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.survicate:survicate-sdk:1.3.0'
+    implementation 'com.survicate:survicate-sdk:1.5.4'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.32'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/ios/survicate_flutter_sdk.podspec
+++ b/ios/survicate_flutter_sdk.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Survicate', '1.5.5'
+  s.dependency 'Survicate', '1.6.1'
   s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: survicate_flutter_sdk
 description: Survicate mobile SDK for Flutter allows you to survey specific groups of your mobile app users to understand their needs, expectations, and objections.
-version: 2.1.1
+version: 2.1.1+1
 homepage: https://github.com/andre-paraense/survicate-flutter-sdk
 issue_tracker: https://github.com/andre-paraense/survicate-flutter-sdk/issues
 


### PR DESCRIPTION
### Requirements

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

### Describe the solution you've provided

This PR updates Survicate iOS SDK to 1.6.1 and Android SDK to 1.5.4.

Also some Android related config is updated as well so the example app could be run locally:
- Kotlin version: 1.4.32
- Android Gradle plugin: 4.2.2
- gradle-wrapper: 6.7.1

